### PR TITLE
Make Ingress Classes Optional

### DIFF
--- a/charts/cert-manager-issuers/Chart.yaml
+++ b/charts/cert-manager-issuers/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: v1.0.0
+version: v1.0.1
 name: cert-manager-issuers
 description: A Helm chart to deploy default cert-manager issuers.
 type: application
-icon: https://raw.githubusercontent.com/eschercloudai/helm-addons/main/icons/default.png
+icon: https://raw.githubusercontent.com/unikorn-cloud/unikorn/main/icons/default.png

--- a/charts/cert-manager-issuers/templates/clusterissuer-production.yaml
+++ b/charts/cert-manager-issuers/templates/clusterissuer-production.yaml
@@ -10,5 +10,7 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: {{ .Values.ingressClass }}
+          {{- with $class := .Values.ingressClass }}
+          ingressClassName: {{ $class }}
+          {{- end }}
           serviceType: {{ .Values.serviceType }}

--- a/charts/cert-manager-issuers/templates/clusterissuer-staging.yaml
+++ b/charts/cert-manager-issuers/templates/clusterissuer-staging.yaml
@@ -10,5 +10,7 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: {{ .Values.ingressClass }}
+          {{- with $class := .Values.ingressClass }}
+          ingressClassName: {{ $class }}
+          {{- end }}
           serviceType: {{ .Values.serviceType }}

--- a/charts/cert-manager-issuers/values.yaml
+++ b/charts/cert-manager-issuers/values.yaml
@@ -1,5 +1,5 @@
 # Sets the ingress class of all issuers.
-ingressClass: nginx
+ingressClass: ~
 
 # serviceType defines the service type to use, may be NodePort or ClusterIP
 serviceType: ClusterIP


### PR DESCRIPTION
There is no guarantee nginx will be the default, so use whatever is marked as the default on the system.